### PR TITLE
Add newrelic example

### DIFF
--- a/examples/java/newrelic-manual/.gitignore
+++ b/examples/java/newrelic-manual/.gitignore
@@ -1,0 +1,3 @@
+target/
+.vscode/
+

--- a/examples/java/newrelic-manual/build.gradle
+++ b/examples/java/newrelic-manual/build.gradle
@@ -1,0 +1,10 @@
+evaluationDependsOn(':')
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+apply plugin: "application"
+mainClassName = "com.tracing.manual.TraceExample"
+
+dependencies {
+}

--- a/examples/java/newrelic-manual/pom.xml
+++ b/examples/java/newrelic-manual/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.tracing.example</groupId>
+  <artifactId>tracing-example</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>tracing-example</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.tracing.TraceExample</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id> <!-- this is used for inheritance merges -->
+            <phase>package</phase> <!-- bind to the packaging phase -->
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/java/newrelic-manual/src/main/java/com/tracing/manual/TraceExample.java
+++ b/examples/java/newrelic-manual/src/main/java/com/tracing/manual/TraceExample.java
@@ -1,0 +1,154 @@
+package com.tracing.manual;
+
+import com.newrelic.agent.bridge.AgentBridge;
+import com.newrelic.agent.bridge.Transaction;
+import com.newrelic.api.agent.DatastoreParameters;
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Segment;
+import com.newrelic.api.agent.Trace;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URL;
+
+
+/**
+ * Single self contained example for a distributed micro application to
+ * demonstrate how different tracing APIs instrument code
+ * 
+ * @author alois.reitbauer
+ *
+ */
+public class TraceExample {
+
+	public static void main(String[] args) {
+
+		try {
+			initServer();
+			initClient();
+		} catch (Exception ex) {
+			System.err.println("Error starting example");
+			System.err.println(ex.toString());
+		}
+
+	}
+
+	private static void initClient() {
+
+		Thread thread = new Thread(new Runnable() {
+			int pos = 0;
+			String[] pathList = { "pathA", "pathB" };
+
+			@Override
+			public void run() {
+				for (;;) {
+					callHandler();
+				}
+			}
+
+			@Trace(dispatcher=true) // This annotation instruments the client
+			private void callHandler() {
+				try {
+					// call the server in a loop
+					System.out.println("Client is calling");
+					pos = (pos + 1) % 2;
+					URL url = new URL("http://localhost:8000/" + pathList[pos]);
+					String payload =  AgentBridge.getAgent().getTransaction().createDistributedTracePayload().text();
+
+					HttpURLConnection con = (HttpURLConnection) url.openConnection();
+					con.setRequestMethod("GET");
+					con.setRequestProperty("NewRelicPayload", payload);
+					BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+					String inputLine;
+					StringBuffer content = new StringBuffer();
+					while ((inputLine = in.readLine()) != null) {
+						content.append(inputLine);
+					}
+					in.close();
+				} catch (Exception e) {
+					System.err.println("Failed to talk to server");
+					System.err.println(e.toString());
+				}
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException ex) {
+					return;
+				}
+			}
+
+		});
+		thread.start();
+	}
+
+	private static void initServer() throws Exception {
+		HttpServer server = HttpServer.create(new InetSocketAddress(8000), 0);
+		server.createContext("/pathA", new PathAHandler());
+		server.createContext("/pathB", new PathBHandler());
+		server.setExecutor(null); // creates a default executor
+		server.start();
+	}
+
+	// server side handlers
+	private static void readNewRelicPayload(HttpExchange t, Transaction txn) {
+		java.util.List<String> tags = t.getRequestHeaders().get("NewRelicPayload");
+		if (tags.size() == 1) {
+			txn.acceptDistributedTracePayload(tags.get(0));
+		} else {
+			System.err.println("zero or more than one tags");
+		}
+	}
+
+	static class PathAHandler implements HttpHandler {
+		@Override
+		@Trace(dispatcher=true)
+		public void handle(HttpExchange t) throws IOException {
+			// add trace context to the Transaction
+			readNewRelicPayload(t, AgentBridge.getAgent().getTransaction());
+
+			String response = "This is path A";
+			t.sendResponseHeaders(200, response.length());
+			OutputStream os = t.getResponseBody();
+			os.write(response.getBytes());
+			System.out.println("Path A was called.");
+			os.close();
+		}
+	}
+
+	static class PathBHandler implements HttpHandler {
+		@Override
+		@Trace(dispatcher=true)
+		public void handle(HttpExchange t) throws IOException {
+			// add trace context to the Transaction
+			readNewRelicPayload(t, AgentBridge.getAgent().getTransaction());
+
+			String response = "This is path B";
+			t.sendResponseHeaders(200, response.length());
+			OutputStream os = t.getResponseBody();
+			os.write(response.getBytes());
+			System.out.println("Path B was called");
+			this.fakeDBCall("select * from table");
+			os.close();
+		}
+
+		public void fakeDBCall(String statement) {
+			// add a segment to the Transaction
+			Segment segment = NewRelic.getAgent().getTransaction().startSegment("database");
+			segment.reportAsExternal(DatastoreParameters
+					.product("FakeDB")
+					.collection("tablename")
+					.operation("SELECT")
+					.build());
+			// this is just to simulate a fake database call
+			System.out.println("Fake DB! was called with statement " + statement);
+			segment.end();
+		}
+
+	}
+}


### PR DESCRIPTION
This example demonstrates how to instrument the client and server with the New Relic Java agent API.

It's a bit contrived: The agent "magically" instruments much of this example, so I have to disable the agent's automatic mode to demonstrate the API. Also, the propagation API is a prototype and is not publicly available.

Regardless, I think it still illustrates how our API instruments the New Relic concepts of a transaction and its segments. This is an example of the spans produced from the path B handler call:

![screen shot 2018-03-30 at 12 57 47 pm](https://user-images.githubusercontent.com/6353483/38164557-5f25ac68-34bb-11e8-8bec-e8a893f6768a.png)
 